### PR TITLE
Fixed issue with sending special keys

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -144,11 +144,13 @@ module.exports = function exportDriverBase(WebDriver) {
         port: port,
         path: prefix + url,
         method: method,
-        headers: {
-          'Content-Type': 'application/json;charset=utf-8',
-          'Content-Length': Buffer.byteLength(body, 'utf8')
-        }
+        headers: {}
       };
+
+      if(method === 'POST' || method === 'PUT') {
+        options.headers['Content-Type'] = 'application/json;charset=utf-8';
+        options.headers['Content-Length'] = Buffer.byteLength(body, 'utf8');
+      }
 
       return options;
     },


### PR DESCRIPTION
Right now there is a bug in the dalek-internal-actions repo (https://github.com/dalekjs/dalek-internal-actions/issues/1) about special keys not working.  The reason the special key are not working is because they use UTF-8 characters in order to send them.  Looking through the selenium's webdriver code, it seems like they send all requests with a method of POST or PUT with UTF-8 encoding so I have updated the driver's generateRequestOptions() method to do the same.
