### PR TITLE
Added sendKeys() method that work on any element, not just inputs

### DIFF
--- a/lib/commands/element.js
+++ b/lib/commands/element.js
@@ -409,4 +409,25 @@ module.exports = function (Driver) {
     }
   });
 
+  /**
+   * Get the log for a given log type.
+   * Log buffer is reset after each request.
+   *
+   * @method sendKeys
+   * @see https://code.google.com/p/selenium/wiki/JsonWireProtocol#POST_/session/:sessionId/keys
+   * @param {GET} sessionId ID of the session to route the command to
+   * @param {GET} id ID of the element to route the command to
+   * @param {POST} text The keys sequence to be sent
+   */
+
+  Driver.addCommand({
+    name: 'sendKeys',
+    url: '/session/:sessionId/keys',
+    method: 'POST',
+    params: ['text'],
+    onRequest: function (params) {
+      return {value: params.text.split('')};
+    }
+  });
+
 };


### PR DESCRIPTION
Part of the code to allow for sending keyboard commands to any input and not just inputs which is what type() does.
