### PR TITLE
Only include files ending in .js

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,10 @@ var Driver = require('./lib/driver')(WebDriver);
 // include webdriver commands
 var dir = __dirname + '/lib/commands/';
 fs.readdirSync(dir).forEach(function (file) {
-  require(dir + file)(Driver);
+  var suffix = '.js';
+  if (file.substring(file.length - suffix.length, file.length) === suffix) {
+    require(dir + file)(Driver);
+  }
 });
 
 // export the webdriver module


### PR DESCRIPTION
Without this, ViM swap files were being incorrectly parsed while I was editing the module.
